### PR TITLE
Support multi-byte characters in requests

### DIFF
--- a/lib/TrustedClient.js
+++ b/lib/TrustedClient.js
@@ -95,7 +95,7 @@ function TrustedClient(options) {
           options.body = JSON.stringify(options.json);
           delete options.json;
           setRequestHeader(options, 'content-type', 'application/json');
-          setRequestHeader(options, 'content-length', options.body.length);
+          setRequestHeader(options, 'content-length', Buffer.byteLength(options.body));
         }
         if (options.jwt) {
           sig.jwt = options.jwt;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trusted-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Nodejs module implementing trusted client over http requests.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Set the content-length header based on byte length, not character length.

I had been getting json parsing errors when I sent text that included Spanish characters into the terms api. There were curly braces missing from the end of the request body. Looks like they were truncated because the content length was set too low.
