### PR TITLE
return request per trusted-client

### DIFF
--- a/lib/TrustedUser.js
+++ b/lib/TrustedUser.js
@@ -5,13 +5,13 @@ var assert = require('assert-plus');
 function TrustedUser(client, token) {
   assert.object(client, 'client');
   assert.string(token, 'token');
-  
+
   Object.defineProperties(this, {
     request: {
       value: function(uri, options, callback) {
         assert.object(options, 'options');
         options.jwt = token;
-        client.request(uri, options, callback);
+        return client.request(uri, options, callback);
       },
       enumerable: true,
       writable: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@leisurelink/trusted-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Nodejs module implementing trusted client over http requests.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
TrustedUser mimicks TrustedClient.request, but fails to return the request object like the super-contract:
https://github.com/LeisureLink/trusted-client/blob/master/lib/TrustedClient.js#L117
