### PR TITLE
makes trustedClient.request return a thenable request stream

### DIFF
--- a/src/trusted-client.js
+++ b/src/trusted-client.js
@@ -215,10 +215,7 @@ export default function TrustedClient(options) {
       data += chunk;
     });
     reqStream.on('end', () => {
-      try {
-        data = JSON.parse(data);
-      } catch(e) {}
-      handler(null, reqStream, data);
+      handler(null, reqStream.response, data);
     });
     reqStream.on('error', (err) => {
       logger.debug('there was an error in the response stream: ', err);


### PR DESCRIPTION
To support streaming for multi-part-form data, this changes the `trustedClient.request` method to return the underlying request object as a thenable. This allows for backward compatibility for use with promises and for piping for use with streams. 
